### PR TITLE
Use Collectors.toCollection(HashSet::new) instead, 

### DIFF
--- a/src/main/java/com/vartan/BankLocks/BankLocksLoader.java
+++ b/src/main/java/com/vartan/BankLocks/BankLocksLoader.java
@@ -4,6 +4,7 @@ import net.runelite.client.config.ConfigManager;
 
 import javax.inject.Inject;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -25,17 +26,17 @@ public class BankLocksLoader {
     /** Returns the set of item IDs saved to config, or an empty set if it doesn't exist. */
     public Set<Integer> loadLockedItems() {
         try {
-        String commaSeparatedItemIds = configManager.getConfiguration(BankLocksConfig.CONFIG_GROUP,
-                BankLocksConfig.LOCKED_ITEMS_CONFIG_NAME);
+            String commaSeparatedItemIds = configManager.getConfiguration(BankLocksConfig.CONFIG_GROUP,
+                    BankLocksConfig.LOCKED_ITEMS_CONFIG_NAME);
             if (commaSeparatedItemIds != null) {
                 return Arrays.stream(commaSeparatedItemIds.split(","))
                         .map(Integer::parseInt)
-                        .collect(Collectors.toSet());
+                        .collect(Collectors.toCollection(HashSet::new));
             }
         } catch (Exception e) {
             // If there is any exception encountered (reading config or converting to Set<Integer>),
             // behave as if there is no saved config.
         }
-        return Set.of();
+        return new HashSet<>();
     }
 }


### PR DESCRIPTION
with no saved config set, it returns an immutable set, which can't be modified in SetUtil.java:11

injected-client - exception in menu callback
java.lang.UnsupportedOperationException: null
at java.base/java.util.ImmutableCollections.uoe(ImmutableCollections.java:142)
at java.base/java.util.ImmutableCollections$AbstractImmutableCollection.add(ImmutableCollections.java:147)
at com.vartan.BankLocks.util.SetUtil.toggleItem(SetUtil.java:13)
at com.vartan.BankLocks.BankLocksPlugin.lambda$onMenuEntryAdded$0(BankLocksPlugin.java:115)
at do.lx(do.java:32778)
at xk.aj(xk.java:137)
at xk.aw(xk.java:174)
at xk.sj(xk.java)
at client.ss(client.java:29289)
at client.ba(client.java:780)
at client.ec(client.java:13161)
at client.bf(client.java:11642)
at bm.bs(bm.java:463)
at bm.lw(bm.java)
at bm.run(bm.java:3778)
at java.base/java.lang.Thread.run(Thread.java:1583)